### PR TITLE
公開用の投稿一覧の修正

### DIFF
--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -19,10 +19,12 @@
           <% end %>
         </div>
         <div class="chat-bubble"><%= post.body %></div>
-          <%= link_to post_path(post), method: :delete, data: { confirm: '本当に削除しますか？' } do %>
-            <i class="fa-regular fa-trash-can fa-sm"></i>
-            <%= render'favorites/favorite', post: post %>
+          <% if current_user == post.user %>
+            <%= link_to post_path(post), method: :delete, data: { confirm: '本当に削除しますか？' } do %>
+              <i class="fa-regular fa-trash-can fa-sm"></i>
+            <% end %>
           <% end %>
+        <%= render'favorites/favorite', post: post %>
       </div>
     <% end %>
   </div>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -7,7 +7,10 @@
           <div class="mb-6 text-center">
             <h1 class="text-xl text-gray-700 font-semibold">新しい投稿を作成</h1>
           </div>
-          <%= form_with(model: @post, local: true,data: { turbo_frame: "private_posts" }, class: "space-y-5") do |form| %>
+          <%= form_with(model: @post, local: true, class: "space-y-5") do |form| %>
+            <% if @post.visibility == '非公開' %>
+              <%= hidden_field_tag :turbo_frame, "private_posts" %>
+            <% end %>
             <div>
               <%= form.label :tag_names, "タグ", class: "block text-gray-700 font-medium mb-2" %>
               <%= form.text_field :tag_names, placeholder: "例）お酒,ビール ", class: "input input-bordered w-full max-w-xs" %>


### PR DESCRIPTION
公開用の投稿をするときの画面遷移が予想の動作をしていなかった為、投稿ボタンをクリック後、公開用の投稿一覧に画面が遷移するようにpostコントローラを主に修正しました。N＋1問題についても再確認しています。