### PR TITLE
画像関連のエラー修正

### DIFF
--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -53,6 +53,6 @@ class BookmarksController < ApplicationController
   end
 
   def bookmark_params
-    params.require(:bookmark).permit(:generated_drink, :generated_word, :generated_info, :image, :image_url, :image_cache, :memo, :is_original)
+    params.require(:bookmark).permit(:generated_drink, :generated_word, :generated_info, :image, :image_cache, :memo, :is_original)
   end
 end

--- a/app/controllers/generatedresults_controller.rb
+++ b/app/controllers/generatedresults_controller.rb
@@ -24,7 +24,7 @@ class GeneratedresultsController < ApplicationController
       request_story(params[:story])
     else
       @generated_results = nil
-      @image_url = nil
+      @image = nil
     end
   end
 
@@ -43,13 +43,13 @@ class GeneratedresultsController < ApplicationController
   #キーワードでリクエスト
   def request_keyword(keyword)
     @generated_results = @service.generate_drink_words(keyword)
-    generate_image_url if @generated_results.present?
+    generate_image if @generated_results.present?
     check_api_response
   end
 
   # ドリンク名から画像のURLを取得
-  def generate_image_url
-    @image_url = @service.generate_image_url(@generated_results[:first_candidate][:drink_name])
+  def generate_image
+    @image = @service.generate_image(@generated_results[:first_candidate][:drink_name])
   end
 
   #storyパラメータでリクエスト
@@ -60,7 +60,7 @@ class GeneratedresultsController < ApplicationController
 
   #レスポンスに問題があった場合の処理
   def check_api_response
-    if @generated_results.nil? #|| @image_url.nil?
+    if @generated_results.nil? || @image.nil?
       flash[:alert] = 'ドリンクの情報または画像を取得できませんでした。'
       redirect_to generatedresults_path # パスにリダイレクト
     end
@@ -73,6 +73,6 @@ class GeneratedresultsController < ApplicationController
 
   #レスポンスのパラメータを許可
   def generatedresult_params
-    params.require(:generatedresult).permit(:generated_drink, :generated_word, :generated_info, :image_url)
+    params.require(:generatedresult).permit(:generated_drink, :generated_word, :generated_info, :image)
   end
 end

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -6,4 +6,21 @@ class Bookmark < ApplicationRecord
   # CarrierWaveのアップローダーをマウント
   # ImageUploader を使用して、カラムにファイルをアップロードできるようになる。
   mount_uploader :image, ImageUploader
+
+  #apiによる生成画像から画像(base64形式)をpngに変換
+  def download_image(base64, filename)
+    #base64をデコード
+    image_data = Base64.decode64(base64)
+
+    # 一時ファイルを作成、base64をこのファイルに書き込む
+    file = Tempfile.new([filename, '.png'])
+    file.binmode #バイナリモードでの書き込みを指定
+    file << image_data #base64データを書き込む
+    file.rewind #ファイルポインタを先頭に戻す
+
+    # CarrierWaveを使用してアップロード
+    self.image = file
+    file.close
+    file.unlink #一時的なファイルのため読み込んだ後削除する
+  end
 end

--- a/app/services/open_ai_service.rb
+++ b/app/services/open_ai_service.rb
@@ -29,15 +29,19 @@ class OpenAiService
     nil
   end
 
-  def generate_image_url(drink_name)
+  def generate_image(drink_name)
     response = @client.images.generate(
       parameters: {
         model: "dall-e-2",
         prompt: "#{drink_name}の飲み物をクローズアップで撮影したような画像を生成してください。背景は白からグレーのグラデーションで、飲み物の質感や色彩が際立つようにしてください。光の反射や陰影を使って、写真のようなリアリズムを表現してください。",
-        size: "256x256"
+        size: "256x256",
+        response_format: "b64_json" # Base64エンコーディングされた画像データをリクエスト
       })
 
-    response.dig("data", 0, "url")
+  # Base64エンコーディングされた画像データを取得
+    response.dig("data", 0, "b64_json")
+  # 取得したBase64データの先頭部分をログに出力
+  #Rails.logger.info "取得したBase64データの先頭: #{base64_data[0..100]}"
   rescue StandardError => e
     # エラーハンドリング: ログに日本語でエラーを記録
     Rails.logger.error("OpenAI画像生成APIエラー: #{e.message}")

--- a/app/uploaders/avatar_uploader.rb
+++ b/app/uploaders/avatar_uploader.rb
@@ -4,8 +4,11 @@ class AvatarUploader < CarrierWave::Uploader::Base
   include CarrierWave::MiniMagick
 
   # Choose what kind of storage to use for this uploader:
-  storage :file
-  # storage :fog
+  if Rails.env.test? #テスト環境の場合
+    storage :file
+  else #開発、本番環境の場合
+    storage :fog
+  end
 
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:
@@ -30,12 +33,7 @@ class AvatarUploader < CarrierWave::Uploader::Base
   # end
 
   #画像を100x100pxにリサイズ
-  process resize_to_limit: [250, 250]
-
-  #サムネイルバージョン用で50x50pxにリサイズ
-  version :thumb do
-    process resize_to_fit: [50, 50]
-  end
+  process resize_to_limit: [100, 100]
 
   # Add an allowlist of extensions which are allowed to be uploaded.
   # For images you might use something like this:

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -4,11 +4,9 @@ class ImageUploader < CarrierWave::Uploader::Base
   include CarrierWave::MiniMagick
 
   # Choose what kind of storage to use for this uploader:
-  if Rails.env.development?
+  if Rails.env.test? #テスト環境の場合
     storage :file
-  elsif Rails.env.test?
-    storage :file
-  else
+  else #開発、本番環境の場合
     storage :fog
   end
 
@@ -45,6 +43,10 @@ class ImageUploader < CarrierWave::Uploader::Base
   # For images you might use something like this:
   def extension_allowlist
     %w(jpg jpeg gif png)
+  end
+
+  def filename
+    original_filename if original_filename
   end
 
   # Override the filename of the uploaded files:

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -34,11 +34,6 @@ class ImageUploader < CarrierWave::Uploader::Base
   #画像を100x100pxにリサイズ
   process resize_to_limit: [350, 350]
 
-  #サムネイルバージョン用で50x50pxにリサイズ
-  version :thumb do
-    process resize_to_fit: [250, 250]
-  end
-
   # Add an allowlist of extensions which are allowed to be uploaded.
   # For images you might use something like this:
   def extension_allowlist

--- a/app/views/bookmarks/_edit.html.erb
+++ b/app/views/bookmarks/_edit.html.erb
@@ -20,11 +20,12 @@
         <%= form.file_field :image, class:'form-control js-file-select-preview', accept: 'image/*', data: { target: '#preview-target' } %>
         <%= form.hidden_field :image_cache %>
     </div>
+    
     <div class="form-group mt-3 mb-3">
       <% if @bookmark.image.present? %>
-        <%= image_tag @bookmark.image.url %>
+        <%= image_tag @bookmark.image.url, id: 'preview-target', size: '250x250' %>
       <% else %>
-        <%= image_tag 'kotonoha_bookmark.png',id: 'preview-target',size: '250x250' %>
+        <%= image_tag '', id: 'preview-target', size: '250x250', alt: 'Image preview' %>
       <% end %>
     </div>
 

--- a/app/views/bookmarks/_edit.html.erb
+++ b/app/views/bookmarks/_edit.html.erb
@@ -18,7 +18,7 @@
     <div class="form-group mb-3 text-left"">
         <%= form.label :image, '画像' %>
         <%= form.file_field :image, class:'form-control js-file-select-preview', accept: 'image/*', data: { target: '#preview-target' } %>
-        <%= form.hidden_field :bookmark_image_cache %>
+        <%= form.hidden_field :image_cache %>
     </div>
     <div class="form-group mt-3 mb-3">
       <% if @bookmark.image.present? %>

--- a/app/views/bookmarks/new.html.erb
+++ b/app/views/bookmarks/new.html.erb
@@ -17,7 +17,7 @@
     <div class="form-group mb-3"">
         <%= form.label :image, '画像' %>
         <%= form.file_field :image, class:'form-control js-file-select-preview', accept: 'image/*', data: { target: '#preview-target' } %>
-        <%= form.hidden_field :bookmark_image_cache %>
+        <%= form.hidden_field :image_cache %>
     </div>
     <div class="form-group mt-3 mb-3">
       <% if @bookmark.image.present? %>

--- a/app/views/bookmarks/show.html.erb
+++ b/app/views/bookmarks/show.html.erb
@@ -17,9 +17,7 @@
     <!-- 画像の表示 -->
     <div class="max-w-md mx-auto">
       <% if @bookmark.image.present? %>
-        <%= image_tag @bookmark.image, alt: "#{@bookmark.generated_drink}の画像", class: "rounded-lg shadow-2xl" %>
-      <% elsif @bookmark.image.present? %>
-        <%= image_tag @bookmark.image, alt: "#{@bookmark.generated_drink}の画像", class: "rounded-lg shadow-2xl" %>
+        <%= image_tag @bookmark.image.url, alt: "#{@bookmark.generated_drink}の画像", class: "rounded-lg shadow-2xl" %>
       <% else %>
         <div class="placeholder rounded-lg shadow-2xl p-4">
           <p class="text-gray-500">画像はありません。</p>

--- a/app/views/bookmarks/show.html.erb
+++ b/app/views/bookmarks/show.html.erb
@@ -16,8 +16,8 @@
   <div class="hero-content flex-col lg:flex-row-reverse">
     <!-- 画像の表示 -->
     <div class="max-w-md mx-auto">
-      <% if @bookmark.image_url.present? %>
-        <%= image_tag @bookmark.image_url, alt: "#{@bookmark.generated_drink}の画像", class: "rounded-lg shadow-2xl" %>
+      <% if @bookmark.image.present? %>
+        <%= image_tag @bookmark.image, alt: "#{@bookmark.generated_drink}の画像", class: "rounded-lg shadow-2xl" %>
       <% elsif @bookmark.image.present? %>
         <%= image_tag @bookmark.image, alt: "#{@bookmark.generated_drink}の画像", class: "rounded-lg shadow-2xl" %>
       <% else %>

--- a/app/views/generatedresults/show.html.erb
+++ b/app/views/generatedresults/show.html.erb
@@ -1,8 +1,8 @@
 <div class="hero min-h-screen bg-base-200">
   <div class="hero-content flex-col lg:flex-row-reverse">
       <% if @generated_results.present? %>
-      <% if @image_url.present? %>
-        <img src="<%= @image_url %>" alt="<%= @generated_results[:drink_name] %>の画像" class="max-w-sm rounded-lg shadow-2xl" />
+      <% if @image.present? %>
+        <img src="data:image/png;base64,<%= @image %>" alt="<%= @generated_results[:drink_name] %>の画像" class="max-w-sm rounded-lg shadow-2xl" />
       <% else %>
         <div class="placeholder max-w-sm rounded-lg shadow-2xl">
           <p class="text-gray-500">画像はありません。</p>
@@ -32,7 +32,7 @@
                       <%= form.hidden_field :generated_drink, value: @generated_results[:first_candidate][:drink_name] %>
                       <%= form.hidden_field :generated_word, value: @generated_results[:first_candidate][:drink_word] %>
                       <%= form.hidden_field :generated_info, value: @generated_results[:first_candidate][:drink_info] %>
-                      <%= form.hidden_field :image_url, value: @image_url %>
+                      <%= form.hidden_field :image, value: @image %>
                       <%= form.submit "結果を保存する", class: "btn btn-primary mr-2" %>
                     <% end %>
                     <!-- シェアボタン -->

--- a/app/views/profiles/_edit.html.erb
+++ b/app/views/profiles/_edit.html.erb
@@ -2,18 +2,17 @@
   <%= form_with model: @user, url: profile_path do |f| %>
     <div class="flex items-center mb-4">
       <!-- プロフィール画像 -->
-      <div class=" mr-4">
-        <%= image_tag @user.avatar.url, class: "w-32 h-32 rounded-full ring ring-primary ring-offset-base-100 ring-offset-2 shadow-lg" %>
+      <div class="mr-4">
+        <%= image_tag @user.avatar.url, class: "w-32 h-32 rounded-full ring ring-primary ring-offset-base-100 ring-offset-2 shadow-lg", id: "preview-target" %>
       </div>
       <!-- ファイルアップロード -->
       <div class="p-4 px-2">
-        <%= f.file_field :avatar, class: "hidden", accept: 'image/*', data: { target: '#preview-target' } %>
+        <%= f.file_field :avatar, class: "hidden js-file-select-preview", id: "user_avatar", accept: 'image/*', data: { target: '#preview-target' } %>
         <label for="user_avatar" class="btn bg-teal-600 hover:bg-teal-800 text-neutral-50 cursor-pointer">
           画像を変更する
         </label>
       </div>
     </div>
-
     <!-- 名前入力フィールド -->
     <div class="mb-4 w-full">
       <%= f.label :名前, class: "text-left block text-sm font-medium mb-1" %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -12,8 +12,6 @@
   </script>
 </head>
 
-
-
 <div class="min-h-screen bg-gray-100 p-4">
   <div class="bg-white p-8 shadow-lg rounded-lg max-w-md mx-auto flex flex-col items-center"> 
     <!-- アバター画像 -->

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,22 +1,25 @@
+# CarrierWaveの設定呼び出し
 require 'carrierwave/storage/abstract'
 require 'carrierwave/storage/file'
 require 'carrierwave/storage/fog'
 
+# 保存先の分岐
 CarrierWave.configure do |config|
-  if Rails.env.production? # 本番環境の場合はS3へアップロード
+  if Rails.env.production? ||  Rails.env.development?  # 本番環境の場合はS3へアップロード
     config.storage :fog
     config.fog_provider = 'fog/aws'
     config.fog_directory  = 'kotonoha-drink' # バケット名
     config.fog_public = false
+    config.asset_host = 'https://s3-ap-northeast-1.amazonaws.com/kotonoha-drink'
     config.fog_credentials = {
       provider: 'AWS',
+      #環境変数で管理
       aws_access_key_id: ENV['S3_ACCESS_KEY_ID'], # アクセスキー
       aws_secret_access_key: ENV['S3_SECRET_ACCESS_KEY'], # シークレットアクセスキー
-      region: 'ap-northeast-1', # リージョン
-      path_style: true
+      region: 'ap-northeast-1', # 東京リージョン
     }
   else # 本番環境以外の場合はアプリケーション内にアップロード
     config.storage :file
-    config.enable_processing = false if Rails.env.test?
+    config.enable_processing = false if Rails.env.test? #test:処理をスキップ
   end
 end

--- a/db/migrate/20240119133310_create_bookmarks.rb
+++ b/db/migrate/20240119133310_create_bookmarks.rb
@@ -6,8 +6,7 @@ class CreateBookmarks < ActiveRecord::Migration[7.0]
       t.string :generated_drink
       t.string :generated_word
       t.text :generated_info
-      t.string :image #アップロード用
-      t.string :image_url #api画像保存用
+      t.string :image 
       t.string :image_cache
       t.text :memo
       t.boolean :is_original

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -20,7 +20,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_30_091741) do
     t.string "generated_word"
     t.text "generated_info"
     t.string "image"
-    t.string "image_url"
     t.string "image_cache"
     t.text "memo"
     t.boolean "is_original"


### PR DESCRIPTION
## 画像関連のエラーを修正しました。
以下詳細になります。正常に動作することを確認しています。
* aws s3への画像保存が正常に動作していなかった為、修正しました。
viewファイルのfield名が違ったことが原因。
開発環境でもs3に保存できるように修正。
* open ai apiによる生成画像をブックマークに保存できなかった為、修正しました。
レスポンスをurl形式からbase64形式で取得するように変更。
bookmarkのimage_urlを削除しimageカラムに統合。
base64をデコードしファイルとしてs3とbookmarkテーブルに保存。
ストレージや画像容量を考慮してuploaderファイルを修正。
* avatar、image画像の更新時にプレビューが表示されない為、修正しました。
