### PR TITLE
ソーシャルシェア、ドリンクギャラリーの画面遷移修正

### DIFF
--- a/app/controllers/socialsharings_controller.rb
+++ b/app/controllers/socialsharings_controller.rb
@@ -1,0 +1,26 @@
+# (ソーシャルシェア兼)みんなが作ったドリンク言葉一覧
+class SocialsharingsController < ApplicationController
+  def show
+    @socialsharing = Socialsharing.find(params[:id])
+  end
+
+  def index
+    @socialsharings = Socialsharing.all.order(created_at: :desc)
+  end
+
+  def create
+    @socialsharing = Socialsharing.new(socialsharing_params)
+    if @socialsharing.save
+      redirect_to socialsharings_path
+    else
+      render :new
+    end
+
+  end
+
+  private
+
+  def socialsharing_params
+    params.require(:socialsharing).permit(:generated_drink, :generated_word, :generated_info, :image)
+  end
+end

--- a/app/controllers/socialsharings_controller.rb
+++ b/app/controllers/socialsharings_controller.rb
@@ -10,10 +10,12 @@ class SocialsharingsController < ApplicationController
 
   def create
     @socialsharing = Socialsharing.new(socialsharing_params)
+    image_data
     if @socialsharing.save
-      image_data
+      redirect_to socialsharing_path(@socialsharing)
+    else
+      render :new
     end
-
   end
 
   private
@@ -22,12 +24,6 @@ class SocialsharingsController < ApplicationController
     base64_image = params[:socialsharing][:image] # フォームから送信されたBase64画像データ
     filename = "socialsharing_#{Time.zone.now.to_i}" # 任意のファイル名
     @socialsharing.download_image(base64_image, filename) if base64_image.present?
-
-    if @socialsharing.save
-      redirect_to socialsharings_path
-    else
-      render :new
-    end
   end
 
   def socialsharing_params

--- a/app/controllers/socialsharings_controller.rb
+++ b/app/controllers/socialsharings_controller.rb
@@ -11,14 +11,24 @@ class SocialsharingsController < ApplicationController
   def create
     @socialsharing = Socialsharing.new(socialsharing_params)
     if @socialsharing.save
-      redirect_to socialsharings_path
-    else
-      render :new
+      image_data
     end
 
   end
 
   private
+
+  def image_data
+    base64_image = params[:socialsharing][:image] # フォームから送信されたBase64画像データ
+    filename = "socialsharing_#{Time.zone.now.to_i}" # 任意のファイル名
+    @socialsharing.download_image(base64_image, filename) if base64_image.present?
+
+    if @socialsharing.save
+      redirect_to socialsharings_path
+    else
+      render :new
+    end
+  end
 
   def socialsharing_params
     params.require(:socialsharing).permit(:generated_drink, :generated_word, :generated_info, :image)

--- a/app/helpers/socialaharings_helper.rb
+++ b/app/helpers/socialaharings_helper.rb
@@ -1,0 +1,2 @@
+module SocialaharingsHelper
+end

--- a/app/models/socialsharing.rb
+++ b/app/models/socialsharing.rb
@@ -1,3 +1,20 @@
 # (ソーシャルシェア兼)みんなが作ったドリンク言葉一覧のモデル
 class Socialsharing < ApplicationRecord
+  # ImageUploader を使用して、カラムにファイルをアップロードできるようになる。
+  mount_uploader :image, ImageUploader
+
+  # apiによる生成画像から画像(base64形式)をpngに変換
+  def download_image(base64, filename)
+    # base64をデコード
+    image_data = Base64.decode64(base64)
+    # 一時ファイルを作成、base64をこのファイルに書き込む
+    file = Tempfile.new([filename, '.png'])
+    file.binmode # バイナリモードでの書き込みを指定
+    file << image_data # base64データを書き込む
+    file.rewind # ファイルポインタを先頭に戻す
+    # CarrierWaveを使用してアップロード
+    self.image = file
+    file.close
+    file.unlink # 一時的なファイルのため読み込んだ後削除する
+  end
 end

--- a/app/models/socialsharing.rb
+++ b/app/models/socialsharing.rb
@@ -1,0 +1,3 @@
+# (ソーシャルシェア兼)みんなが作ったドリンク言葉一覧のモデル
+class Socialsharing < ApplicationRecord
+end

--- a/app/views/bookmarks/show.html.erb
+++ b/app/views/bookmarks/show.html.erb
@@ -25,7 +25,7 @@
     </div>
 
     <!-- カード -->
-    <div class="card w-full bg-base-100 shadow-xl max-w-lg mx-auto">
+    <div class="card w-full bg-white shadow-xl max-w-lg mx-auto">
       <div class="card-body">
         <h2 class="card-title text-4xl mb-4">ドリンク情報</h2>
 

--- a/app/views/generatedresults/show.html.erb
+++ b/app/views/generatedresults/show.html.erb
@@ -1,4 +1,4 @@
-<div class="hero min-h-screen bg-base-200">
+<div class="hero min-h-screen bg-gray-100">
   <%= render "shared/loading" %>
   <div class="hero-content flex-col lg:flex-row-reverse">
       <% if @generated_results.present? %>
@@ -9,9 +9,9 @@
           <p class="text-gray-500">画像はありません。</p>
         </div>
       <% end %>
-      <div class="hero min-h-screen bg-base-200">
+      <div class="hero min-h-screen bg-gray-100">
         <div class="hero-content flex-col lg:flex-row-reverse">
-          <div class="card w-full bg-base-100 shadow-xl">
+          <div class="card w-full bg-white shadow-xl">
             <div class="card-body">
               <h2 class="card-title text-4xl">ドリンク情報</h2>
 
@@ -33,19 +33,18 @@
                       <%= form.submit "結果を保存する", class: "btn btn-primary mr-2" %>
                     <% end %>
                     <!-- シェアボタン -->
-                    <button class="btn btn-outline btn-info bg-black hover:bg-gray-800 text-white">
-                      <%= link_to "https://twitter.com/intent/tweet?url=#{CGI.escape(request.url)}&text=#{CGI.escape("#{@generated_results[:drink_name]}のドリンク言葉は#{@generated_results[:drink_word]}らしいよ〜")}", title: 'Twitter', target: '_blank', class: "flex items-center" do %>
-                        <i class="fa-brands fa-square-x-twitter fa-lg"></i>に投稿する
-                      <% end %>
-                    </button>
+                      <%= render "shared/sharingbutton" %>
                   </div>
                 <% else %>
                     <!-- シェアボタン -->
-                    <button class="btn btn-outline btn-info bg-black hover:bg-gray-800 text-white">
-                      <%= link_to "https://twitter.com/intent/tweet?url=#{CGI.escape(request.url)}&text=#{CGI.escape("#{@generated_results[:drink_name]}のドリンク言葉は#{@generated_results[:drink_word]}らしいよ〜")}", title: 'Twitter', target: '_blank', class: "flex items-center" do %>
-                        <i class="fa-brands fa-square-x-twitter fa-lg"></i>に投稿する
-                      <% end %>
-                    </button>
+                    <%= form_with model: Socialsharing.new, url: socialsharings_path, local: true do |form| %>
+                      <!-- フォームのフィールド -->
+                      <%= form.hidden_field :generated_drink, value: @generated_results[:drink_name] %>
+                      <%= form.hidden_field :generated_word, value: @generated_results[:drink_word] %>
+                      <%= form.hidden_field :generated_info, value: @generated_results[:drink_info] %>
+                      <%= form.hidden_field :image, value: @image %>
+                      <%= form.submit "xに投稿する", class: "btn btn-primary mr-2" %>
+                    <% end %>
                 <% end %>
               </div>
             </div>

--- a/app/views/generatedresults/show.html.erb
+++ b/app/views/generatedresults/show.html.erb
@@ -25,26 +25,19 @@
                 <% if user_signed_in? && @generated_results.present? %>
                   <div class="flex items-center">
                     <%= form_with model: Bookmark.new, url: bookmarks_path, local: true do |form| %>
-                      <!-- フォームのフィールド -->
+                      <!-- 結果を保存 -->
                       <%= form.hidden_field :generated_drink, value: @generated_results[:drink_name] %>
                       <%= form.hidden_field :generated_word, value: @generated_results[:drink_word] %>
                       <%= form.hidden_field :generated_info, value: @generated_results[:drink_info] %>
                       <%= form.hidden_field :image, value: @image %>
                       <%= form.submit "結果を保存する", class: "btn btn-primary mr-2" %>
                     <% end %>
-                    <!-- シェアボタン -->
+                    <!-- ドリンクシェア -->
                       <%= render "shared/sharingbutton" %>
                   </div>
                 <% else %>
-                    <!-- シェアボタン -->
-                    <%= form_with model: Socialsharing.new, url: socialsharings_path, local: true do |form| %>
-                      <!-- フォームのフィールド -->
-                      <%= form.hidden_field :generated_drink, value: @generated_results[:drink_name] %>
-                      <%= form.hidden_field :generated_word, value: @generated_results[:drink_word] %>
-                      <%= form.hidden_field :generated_info, value: @generated_results[:drink_info] %>
-                      <%= form.hidden_field :image, value: @image %>
-                      <%= form.submit "xに投稿する", class: "btn btn-primary mr-2" %>
-                    <% end %>
+                  <!-- ドリンクシェア -->
+                  <%= render "shared/sharingbutton" %>
                 <% end %>
               </div>
             </div>

--- a/app/views/shared/_header_logged_in.html.erb
+++ b/app/views/shared/_header_logged_in.html.erb
@@ -33,6 +33,9 @@
             </li>
           </ul>
         </div>
+        <%= link_to socialsharings_path, class: "btn bg-indigo-500 hover:bg-indigo-600 text-white ml-2" do %>
+          <i class="fa-solid fa-champagne-glasses fa-sm"></i>
+        <% end %>
       </div>
     </div> 
     <div class="drawer-side z-20	z-index: 20;">
@@ -61,7 +64,7 @@
         </li>
         <li>
           <a href="<%= generatedresult_path %>">
-            <i class="fa-solid fa-champagne-glasses fa-sm"></i>ドリンクを注文する
+            <i class="fa-solid fa-bell-concierge fa-sm"></i>ドリンクを注文する
           </a>
         </li>
         <li>

--- a/app/views/shared/_header_logged_out.html.erb
+++ b/app/views/shared/_header_logged_out.html.erb
@@ -27,5 +27,8 @@
         </li>
       </ul>
     </div>
+            <%= link_to socialsharings_path, class: "btn bg-indigo-500 hover:bg-indigo-600 text-white ml-2" do %>
+          <i class="fa-solid fa-champagne-glasses fa-sm"></i>
+        <% end %>
   </div>
 </header>

--- a/app/views/shared/_sharingbutton.html.erb
+++ b/app/views/shared/_sharingbutton.html.erb
@@ -1,5 +1,10 @@
-<button class="btn btn-outline btn-info bg-black hover:bg-gray-800 text-white">
-  <%= link_to "https://twitter.com/intent/tweet?url=#{CGI.escape(request.url)}&text=#{CGI.escape("#{@generated_results[:drink_name]}のドリンク言葉は#{@generated_results[:drink_word]}らしいよ〜")}", title: 'Twitter', target: '_blank', class: "flex items-center" do %>
-    <i class="fa-brands fa-square-x-twitter fa-lg"></i>に投稿する
-  <% end %>
-</button>
+<%= form_with model: Socialsharing.new, url: socialsharings_path, local: true, id: "socialsharing-form", class: "socialsharing-form" do |form| %>
+  <%= form.hidden_field :generated_drink, value: @generated_results[:drink_name] %>
+  <%= form.hidden_field :generated_word, value: @generated_results[:drink_word] %>
+  <%= form.hidden_field :generated_info, value: @generated_results[:drink_info] %>
+  <%= form.hidden_field :image, value: @image %>
+  <!-- シェアボタン -->
+  <button type="submit" class="btn btn-outline btn-info bg-black hover:bg-gray-800 text-white flex items-center">
+    <i class="fa-solid fa-champagne-glasses fa-sm"></i>ドリンクをシェアする
+  </button>
+<% end %>

--- a/app/views/shared/_sharingbutton.html.erb
+++ b/app/views/shared/_sharingbutton.html.erb
@@ -1,5 +1,5 @@
-                <button class="btn btn-outline btn-info bg-black hover:bg-gray-800 text-white">
-                      <%= link_to "https://twitter.com/intent/tweet?url=#{CGI.escape(request.url)}&text=#{CGI.escape("#{@generated_results[:drink_name]}のドリンク言葉は#{@generated_results[:drink_word]}らしいよ〜")}", title: 'Twitter', target: '_blank', class: "flex items-center" do %>
-                        <i class="fa-brands fa-square-x-twitter fa-lg"></i>に投稿する
-                      <% end %>
-                    </button>
+<button class="btn btn-outline btn-info bg-black hover:bg-gray-800 text-white">
+  <%= link_to "https://twitter.com/intent/tweet?url=#{CGI.escape(request.url)}&text=#{CGI.escape("#{@generated_results[:drink_name]}のドリンク言葉は#{@generated_results[:drink_word]}らしいよ〜")}", title: 'Twitter', target: '_blank', class: "flex items-center" do %>
+    <i class="fa-brands fa-square-x-twitter fa-lg"></i>に投稿する
+  <% end %>
+</button>

--- a/app/views/shared/_sharingbutton.html.erb
+++ b/app/views/shared/_sharingbutton.html.erb
@@ -1,0 +1,5 @@
+                <button class="btn btn-outline btn-info bg-black hover:bg-gray-800 text-white">
+                      <%= link_to "https://twitter.com/intent/tweet?url=#{CGI.escape(request.url)}&text=#{CGI.escape("#{@generated_results[:drink_name]}のドリンク言葉は#{@generated_results[:drink_word]}らしいよ〜")}", title: 'Twitter', target: '_blank', class: "flex items-center" do %>
+                        <i class="fa-brands fa-square-x-twitter fa-lg"></i>に投稿する
+                      <% end %>
+                    </button>

--- a/app/views/socialsharings/index.html.erb
+++ b/app/views/socialsharings/index.html.erb
@@ -1,10 +1,10 @@
 <div class="hero min-h-screen bg-gray-100">
   <div class="container mx-auto px-4 py-8">
-    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-6">
       <% @socialsharings.each do |socialsharing| %>
         <div class="relative overflow-hidden shadow-lg rounded-lg">
           <% if socialsharing.image.present? %>
-            <%= image_tag socialsharing.image, class: "w-full h-full object-cover transition duration-500 ease-in-out transform hover:scale-105" %>
+            <%= image_tag socialsharing.image.url, class: "w-full h-full object-cover transition duration-500 ease-in-out transform hover:scale-105" %>
           <% else %>
             <%= image_tag "kotonoha_drink logo.png", size: '250x250', class: "w-full h-full object-cover transition duration-500 ease-in-out transform hover:scale-105" %>
           <% end %>

--- a/app/views/socialsharings/index.html.erb
+++ b/app/views/socialsharings/index.html.erb
@@ -3,15 +3,17 @@
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-6">
       <% @socialsharings.each do |socialsharing| %>
         <div class="relative overflow-hidden shadow-lg rounded-lg">
-          <% if socialsharing.image.present? %>
-            <%= image_tag socialsharing.image.url, class: "w-full h-full object-cover transition duration-500 ease-in-out transform hover:scale-105" %>
-          <% else %>
-            <%= image_tag "kotonoha_drink logo.png", size: '250x250', class: "w-full h-full object-cover transition duration-500 ease-in-out transform hover:scale-105" %>
+          <%= link_to socialsharing_path(socialsharing) do %>
+            <% if socialsharing.image.present? %>
+              <%= image_tag socialsharing.image.url, class: "w-full h-full object-cover transition duration-500 ease-in-out transform hover:scale-105" %>
+            <% else %>
+              <%= image_tag "kotonoha_drink logo.png", size: '250x250', class: "w-full h-full object-cover transition duration-500 ease-in-out transform hover:scale-105" %>
+            <% end %>
+            <div class="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black to-transparent p-4">
+              <h2 class="text-xl text-white font-bold truncate"><%= socialsharing.generated_drink %></h2>
+              <p class="text-sm text-white truncate"><%= socialsharing.generated_word %></p>
+            </div>
           <% end %>
-          <div class="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black to-transparent p-4">
-            <h2 class="text-xl text-white font-bold truncate"><%= socialsharing.generated_drink %></h2>
-            <p class="text-sm text-white truncate"><%= socialsharing.generated_word %></p>
-          </div>
         </div>
       <% end %>
     </div>

--- a/app/views/socialsharings/index.html.erb
+++ b/app/views/socialsharings/index.html.erb
@@ -1,0 +1,19 @@
+<div class="hero min-h-screen bg-gray-100">
+  <div class="container mx-auto px-4 py-8">
+    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+      <% @socialsharings.each do |socialsharing| %>
+        <div class="relative overflow-hidden shadow-lg rounded-lg">
+          <% if socialsharing.image.present? %>
+            <%= image_tag socialsharing.image, class: "w-full h-full object-cover transition duration-500 ease-in-out transform hover:scale-105" %>
+          <% else %>
+            <%= image_tag "kotonoha_drink logo.png", size: '250x250', class: "w-full h-full object-cover transition duration-500 ease-in-out transform hover:scale-105" %>
+          <% end %>
+          <div class="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black to-transparent p-4">
+            <h2 class="text-xl text-white font-bold truncate"><%= socialsharing.generated_drink %></h2>
+            <p class="text-sm text-white truncate"><%= socialsharing.generated_word %></p>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/socialsharings/show.html.erb
+++ b/app/views/socialsharings/show.html.erb
@@ -1,0 +1,34 @@
+
+<div class="hero min-h-screen bg-gray-100">
+  <%= render "shared/loading" %>
+  <div class="hero-content flex-col lg:flex-row-reverse">
+    <!-- 画像の表示 -->
+    <div class="max-w-md mx-auto">
+      <% if @socialsharing.image.present? %>
+        <%= image_tag @socialsharing.image, alt: "#{@socialsharing.generated_drink}の画像", class: "rounded-lg shadow-2xl" %>
+      <% else %>
+        <%= image_tag "kotonoha_drink logo.png", size: '250x250', class: "rounded-lg shadow-2xl" %>
+      <% end %>
+    </div>
+
+    <!-- カード -->
+    <div class="card w-full bg-white shadow-xl max-w-lg mx-auto">
+      <div class="card-body">
+        <h2 class="card-title text-4xl mb-4">ドリンク情報</h2>
+
+        <div class="mb-4">
+          <span class="text-lg"><strong>ドリンク名:</strong> <%= @socialsharing.generated_drink %></span>
+        </div>
+
+        <div class="mb-4">
+          <p class="text-lg"><strong>ドリンク言葉:</strong> <%= @socialsharing.generated_word %></p>
+        </div>
+
+        <div class="mb-4">
+          <p class="text-lg"><strong>ドリンク情報:</strong> <%= @socialsharing.generated_info %></p>
+        </div>
+
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/socialsharings/show.html.erb
+++ b/app/views/socialsharings/show.html.erb
@@ -28,6 +28,12 @@
           <p class="text-lg"><strong>ドリンク情報:</strong> <%= @socialsharing.generated_info %></p>
         </div>
 
+        <button class="btn btn-outline btn-info bg-black hover:bg-gray-800 text-white">
+          <%= link_to "https://twitter.com/intent/tweet?url=#{CGI.escape(request.url)}&text=#{CGI.escape("#{@socialsharing.generated_drink}のドリンク言葉は#{@socialsharing.generated_word}らしいよ〜")}", title: 'Twitter', target: '_blank', class: "flex items-center" do %>
+            <i class="fa-brands fa-square-x-twitter fa-lg"></i>にも投稿する？
+          <% end %>
+        </button>
+
       </div>
     </div>
   </div>

--- a/app/views/socialsharings/show.html.erb
+++ b/app/views/socialsharings/show.html.erb
@@ -5,7 +5,7 @@
     <!-- 画像の表示 -->
     <div class="max-w-md mx-auto">
       <% if @socialsharing.image.present? %>
-        <%= image_tag @socialsharing.image, alt: "#{@socialsharing.generated_drink}の画像", class: "rounded-lg shadow-2xl" %>
+        <%= image_tag @socialsharing.image.url, alt: "#{@socialsharing.generated_drink}の画像", class: "rounded-lg shadow-2xl" %>
       <% else %>
         <%= image_tag "kotonoha_drink logo.png", size: '250x250', class: "rounded-lg shadow-2xl" %>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
   get 'generatedresults', to: 'generatedresults#show'
   resource :profile, only: %i[show edit update]
   resources :bookmarks
+  resources :socialsharings, only: %i[show index create]
   resources :posts do
     resource :favorites, only: %i[create destroy]
     collection do

--- a/db/migrate/20240213075003_create_socialsharings.rb
+++ b/db/migrate/20240213075003_create_socialsharings.rb
@@ -1,0 +1,13 @@
+class CreateSocialsharings < ActiveRecord::Migration[7.0]
+  def change
+    create_table :socialsharings do |t|
+
+      t.string :generated_drink
+      t.string :generated_word
+      t.text :generated_info
+      t.string :image
+      
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_30_091741) do
+ActiveRecord::Schema[7.0].define(version: 2024_02_13_075003) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -74,6 +74,15 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_30_091741) do
     t.datetime "updated_at", null: false
     t.index ["post_id"], name: "index_posttags_on_post_id"
     t.index ["tag_id"], name: "index_posttags_on_tag_id"
+  end
+
+  create_table "socialsharings", force: :cascade do |t|
+    t.string "generated_drink"
+    t.string "generated_word"
+    t.text "generated_info"
+    t.string "image"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "tags", force: :cascade do |t|

--- a/test/controllers/socialaharings_controller_test.rb
+++ b/test/controllers/socialaharings_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class SocialaharingsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/socialsharings.yml
+++ b/test/fixtures/socialsharings.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/socialsharing_test.rb
+++ b/test/models/socialsharing_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class SocialsharingTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
### ソーシャルシェア、ドリンクギャラリーの画面遷移修正をしました。
xへ投稿されたリンクをクリックすると再度api通信してしまい、元のページが表示されない為、修正を行いました。
以下詳細になります。
* 全ユーザーが投稿できるドリンクギャラリーを作成
* ドリンクをシェアでsocialsharing#showを表示、ここにxへのソーシャルシェアボタンを設置
* socialsharing#indexであるドリンクギャラリーはヘッダーに設置
[![Image from Gyazo](https://i.gyazo.com/9e01d885c72f56743e43b6cec7b57982.gif)](https://gyazo.com/9e01d885c72f56743e43b6cec7b57982)