### PR TITLE
レビュー後、UIの変更、ドリンクシェア詳細と投稿に関連する修正

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -21,6 +21,8 @@ class PostsController < ApplicationController
     # 非公開投稿を取得
     @private_posts = @q.result.where(visibility: Post.visibilities[:非公開]).order(created_at: :desc)
     @post = current_user.posts.new
+    @post.tag_names = params[:tag_names] if params[:tag_names].present?
+    @post.body = params[:body] if params[:body].present?
   end
 
   def edit

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -2,6 +2,9 @@
 
 # 投稿のモデル
 class Post < ApplicationRecord
+  #socialsharing外部インスタンス➡️postにパラメータを渡してtag_nameに新しい値を入れるためメソッド追加
+  attr_accessor :tag_names
+
   belongs_to :user
   has_many :posttags, dependent: :destroy
   has_many :tags, through: :posttags

--- a/app/views/bookmarks/index.html.erb
+++ b/app/views/bookmarks/index.html.erb
@@ -1,7 +1,7 @@
 <div class="hero min-h-screen bg-gray-100">
   <%= render "shared/loading" %>
   <div class="text-center" >
-    <h1 class="text-4xl font-bold mb-2 p-2">ドリンク言葉集</h1>
+    <h1 class="text-4xl font-bold mb-2 p-2">保存したドリンク一覧</h1>
     <div class="bg-base-200 sticky top-0 z-10">
       <!-- 検索と並び替えフォーム -->
       <%= form_tag bookmarks_path, method: :get, class: " p-2" do %>

--- a/app/views/bookmarks/show.html.erb
+++ b/app/views/bookmarks/show.html.erb
@@ -14,7 +14,7 @@
 
 <div class="hero min-h-screen bg-gray-100">
   <%= render "shared/loading" %>
-  <div class="hero-content flex-col lg:flex-row-reverse">
+  <div class="hero-content flex-col">
     <!-- 画像の表示 -->
     <div class="max-w-md mx-auto">
       <% if @bookmark.image.present? %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -35,6 +35,14 @@
         <%= render "shared/google_logged_in" %>
       </div>
 
+      <p class="p-8">初めての方はこちらから</p>
+
+<% if devise_mapping.registerable? && controller_name != 'registrations' %>
+  <%= link_to new_registration_path(resource_name), class: "btn w-full max-w-xs bg-indigo-500 hover:bg-indigo-600 text-neutral-50" do %>
+    新規登録
+  <% end %>
+<% end %>
+
       <div class="p-8 text-black">
         <%= render "devise/shared/links" %>
       </div>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -2,10 +2,6 @@
   <%= link_to "ログインはこちら", new_session_path(resource_name) %><br />
 <% end %>
 
-<%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "新規登録がお済みでない方はこちら", new_registration_path(resource_name) %><br />
-<% end %>
-
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
   <%= link_to "パスワードをお忘れですか？", new_password_path(resource_name) %><br />
 <% end %>

--- a/app/views/generatedresults/new.html.erb
+++ b/app/views/generatedresults/new.html.erb
@@ -1,9 +1,9 @@
 <div class="hero min-h-screen bg-gray-100">
   <%= render "shared/loading" %>
   <%= form_with model: @story_form, url: generatedresults_path, method: :get, local: true, id: 'story-form', class: "flex flex-col gap-4 p-4 max-w-md mx-auto" do |form| %>
-    <%= form.text_area :story, placeholder: "ここに注文を書いてください。例）2月で旬な飲み物は何かありますか？アルコールで。例2）友達に紅茶をプレゼントしたい。フルーティーで珍しい紅茶を教えて。", class: "textarea textarea-bordered w-full", rows: 3, maxlength: 60, id: "story-textarea" %>
+    <%= form.text_area :story, placeholder: "ここに注文を書いてください。例）希望という意味のドリンクをノンアルコールで作ってください。例2）友達に紅茶をプレゼントしたい。フルーティーで珍しい紅茶を教えて。", class: "textarea textarea-bordered w-full", rows: 3, maxlength: 60, id: "story-textarea" %>
     <span id="char-count" class="text-gray-600">残りの文字数: 60</span>
-    <%= form.submit "検索", class: "btn btn-primary w-full mt-4" %>
+    <%= form.submit "注文する", class: "btn btn-primary w-full mt-4" %>
   <%= image_tag 'kotonoha_situation.png',class: "p-10  mt-8 mx-12 w-auto max-sm:hidden",size: '250x250'%>
   <%= image_tag 'kotonoha_situation.png',class: "px-14 m-6 w-auto sm:hidden ",size: '100x100'%>
   <div class="text-center">

--- a/app/views/generatedresults/show.html.erb
+++ b/app/views/generatedresults/show.html.erb
@@ -1,6 +1,6 @@
 <div class="hero min-h-screen bg-gray-100">
   <%= render "shared/loading" %>
-  <div class="hero-content flex-col lg:flex-row-reverse">
+  <div class="hero-content flex-col">
       <% if @generated_results.present? %>
       <% if @image.present? %>
         <img src="data:image/png;base64,<%= @image %>" alt="<%= @generated_results[:drink_name] %>の画像" class="max-w-sm rounded-lg shadow-2xl" />
@@ -9,10 +9,8 @@
           <p class="text-gray-500">画像はありません。</p>
         </div>
       <% end %>
-      <div class="hero min-h-screen bg-gray-100">
-        <div class="hero-content flex-col lg:flex-row-reverse">
-          <div class="card w-full bg-white shadow-xl">
-            <div class="card-body">
+          <div class="card w-full bg-white shadow-xl max-w-lg mx-auto">
+            <div class="card-body p-4 sm:p-6">
               <h2 class="card-title text-4xl">ドリンク情報</h2>
 
               <div class="mb-4">
@@ -30,7 +28,7 @@
                       <%= form.hidden_field :generated_word, value: @generated_results[:drink_word] %>
                       <%= form.hidden_field :generated_info, value: @generated_results[:drink_info] %>
                       <%= form.hidden_field :image, value: @image %>
-                      <%= form.submit "結果を保存する", class: "btn btn-primary mr-2" %>
+                      <%= form.submit "結果を保存", class: "btn btn-primary mr-2" %>
                     <% end %>
                     <!-- ドリンクシェア -->
                       <%= render "shared/sharingbutton" %>
@@ -42,8 +40,6 @@
               </div>
             </div>
           </div>
-        </div>
-      </div>
     <% else %>
       <div class="hero min-h-screen bg-base-200">
         <div class="hero-content text-center">

--- a/app/views/posts/_private_posts.html.erb
+++ b/app/views/posts/_private_posts.html.erb
@@ -1,12 +1,9 @@
 <%= turbo_frame_tag "private_posts" do %>
-  <h1 class="text-lg p-6">非公開</h1>
+  <h1 class="text-lg p-6">非公開投稿</h1>
   <div class="flex items-center justify-center text-left">
     <div class="overflow-x-auto h-96">
       <table class="table table-pin-rows table-pin-cols">
         <tbody>
-          <tr>
-            <th>日記</th>
-          </tr>
             <% private_posts.each do |post| %>
               <tr>
                 <td>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -14,11 +14,11 @@
             <% end %>
             <div>
               <%= form.label :tag_names, "タグ", class: "block text-gray-700 font-medium mb-2" %>
-              <%= form.text_field :tag_names, placeholder: "例）お酒,ビール ", class: "input input-bordered w-full max-w-xs" %>
+              <%= form.text_field :tag_names, value: @post.tag_names || params[:tag_names], placeholder: "例）お酒,ビール", class: "input input-bordered w-full max-w-xs" %>
             </div>
             <div>
               <%= form.label :body, "投稿内容", class: "block text-gray-700 font-medium mb-2" %>
-              <%= form.text_area :body, rows: 4, placeholder: "飲み物に関する内容を自由に投稿してください",class: "w-full px-3 py-2 text-gray-700 border rounded-lg focus:outline-none focus:border-blue-500" %>
+              <%= form.text_area :body, rows: 4, value: @post.body || params[:body] ,placeholder: "飲み物に関する内容を自由に投稿してください",class: "w-full px-3 py-2 text-gray-700 border rounded-lg focus:outline-none focus:border-blue-500" %>
             </div>
             <fieldset class="mt-4">
               <legend class="text-gray-700 font-medium mb-2">公開設定</legend>

--- a/app/views/shared/_header_logged_in.html.erb
+++ b/app/views/shared/_header_logged_in.html.erb
@@ -4,28 +4,23 @@
     <input id="my-drawer-3" type="checkbox" class="drawer-toggle" /> 
     <div class="drawer-content">
       <!-- Navbar -->
-      <div class="w-full navbar bg-white">
+      <div class="w-full navbar bg-white justify-between"> 
         <div class="flex-none ">
           <label for="my-drawer-3" aria-label="open sidebar" class="btn btn-square btn-ghost">
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="inline-block w-6 h-6 stroke-current"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path></svg>
           </label>
-        </div> 
-        <div class="flex-1 px-2 mx-2 max-sm:hidden">
+      </div> 
+      <div class="flex-1 px-2 mx-2 max-sm:hidden">
           <a class="font-medium text-green-700 text-xl">言の葉</a>
             <%= image_tag 'kotonoha_drink logo.png',size: '50x50'%>
           <a class="text-black text-xl">rink</a></div>
           <%= form_with url: generatedresults_path, method: :get, local: true, id: 'drink-search-form' do |form| %>
             <%= form.text_field :keyword, placeholder: "ドリンク名を入力", class: "text-sm text-green-700 border border-emerald-700 bg-slate-50 input input-bordered input-md w-full max-w-lg" %>
-            <%= form.submit "検索", class: "btn btn-primary" %>
+            <%= form.submit "作成", class: "btn btn-primary" %>
           <% end %>
         <div class="flex-none hidden md:block">
           <ul class="menu menu-horizontal">
             <!-- Navbar menu content here -->
-            <li>
-              <%= link_to destroy_user_session_path, method: :delete do %>
-                <i class="fa-solid fa-right-from-bracket "></i>ログアウト
-              <% end %>
-            </li>
             <li>
               <a href="<%= drink_menus_path %>">
                 <i class="fa-solid fa-book-open fa-sm "></i>メニュー表
@@ -33,9 +28,11 @@
             </li>
           </ul>
         </div>
-        <%= link_to socialsharings_path, class: "btn bg-indigo-500 hover:bg-indigo-600 text-white ml-2" do %>
-          <i class="fa-solid fa-champagne-glasses fa-sm"></i>
-        <% end %>
+        <div class="tooltip tooltip-bottom" data-tip="Share">
+          <%= link_to socialsharings_path, class: "btn bg-indigo-500 hover:bg-indigo-600 text-white ml-2" do %>
+            <i class="fa-solid fa-champagne-glasses fa-sm"></i>
+          <% end %>
+        </div>
       </div>
     </div> 
     <div class="drawer-side z-20	z-index: 20;">

--- a/app/views/shared/_header_logged_out.html.erb
+++ b/app/views/shared/_header_logged_out.html.erb
@@ -1,34 +1,65 @@
 <!-- ナビゲーションバー(ログイン前) -->
 <header>
-  <div class="w-full navbar bg-white">  
-    <div class="px-2 max-sm:hidden">
-      <a class="font-medium text-green-700 text-xl">言の葉</a>
-          <%= image_tag 'kotonoha_drink logo.png',size: '50x50'%>
-      <a class="text-black text-xl">rink</a>
-    </div>
-    <%= form_with url: generatedresults_path, method: :get, local: true, id: 'drink-search-form' do |form| %>
-      <%= form.text_field :keyword, placeholder: "ドリンク名を入力", class: "text-sm text-green-700 border border-emerald-700 bg-slate-50 input input-bordered input-md w-full max-w-lg" %>
-      <%= form.submit "検索", class: "btn btn-primary" %>
-    <% end %>
-    <div class="flex-none">
-      <ul class="menu menu-horizontal">
-        <!-- Navbar menu content here -->
+  <div class="drawer z-20 relative">
+    <input id="my-drawer-3" type="checkbox" class="drawer-toggle" /> 
+    <div class="drawer-content">
+      <!-- Navbar -->
+      <div class="w-full navbar bg-white justify-between"> 
+        <div class="flex-none ">
+          <label for="my-drawer-3" aria-label="open sidebar" class="btn btn-square btn-ghost">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="inline-block w-6 h-6 stroke-current"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path></svg>
+          </label>
+      </div> 
+      <div class="flex-1 px-2 mx-2 max-sm:hidden">
+          <a class="font-medium text-green-700 text-xl">言の葉</a>
+            <%= image_tag 'kotonoha_drink logo.png',size: '50x50'%>
+          <a class="text-black text-xl">rink</a></div>
+          <%= form_with url: generatedresults_path, method: :get, local: true, id: 'drink-search-form' do |form| %>
+            <%= form.text_field :keyword, placeholder: "ドリンク名を入力", class: "text-sm text-green-700 border border-emerald-700 bg-slate-50 input input-bordered input-md w-full max-w-lg" %>
+            <%= form.submit "作成", class: "btn btn-primary" %>
+          <% end %>
+        <div class="flex-none hidden md:block">
+          <ul class="menu menu-horizontal">
+            <!-- Navbar menu content here -->
+            <li>
+              <a href="<%= drink_menus_path %>">
+                <i class="fa-solid fa-book-open fa-sm "></i>メニュー表
+              </a>
+            </li>
+          </ul>
+        </div>
+        <div class="tooltip tooltip-bottom" data-tip="Share">
+          <%= link_to socialsharings_path, class: "btn bg-indigo-500 hover:bg-indigo-600 text-white ml-2" do %>
+            <i class="fa-solid fa-champagne-glasses fa-sm"></i>
+          <% end %>
+        </div>
+      </div>
+    </div> 
+    <div class="drawer-side z-20	z-index: 20;">
+      <label for="my-drawer-3" aria-label="close sidebar" class="drawer-overlay"></label> 
+      <ul class="menu p-4 w-80 min-h-full bg-stone-300">
+        <!-- Sidebar content here -->
         <li>
-          <a href="<%= new_user_session_path %>">
-            <i class="fa-solid fa-right-to-bracket fa-sm "></i>
-            <p class="hidden md:block">ログイン</p>
-          </a>
+        <a href="<%= root_path %>">
+          <i class="fa-solid fa-house fa-sm"></i>ホーム
+        </a>
         </li>
         <li>
           <a href="<%= drink_menus_path %>">
-            <i class="fa-solid fa-book-open fa-sm "></i>
-            <p class="hidden md:block">メニュー表</p>
+            <i class="fa-solid fa-book-open fa-sm"></i>メニュー表
+          </a>
+        </li>
+        <li>
+          <a href="<%= socialsharings_path %>">
+            <i class="fa-solid fa-champagne-glasses fa-sm"></i>みんなのドリンク
+          </a>
+        </li>
+        <li>
+          <a href="<%= new_user_session_path %>">
+            <i class="fa-solid fa-right-to-bracket fa-sm "></i>ログイン
           </a>
         </li>
       </ul>
     </div>
-            <%= link_to socialsharings_path, class: "btn bg-indigo-500 hover:bg-indigo-600 text-white ml-2" do %>
-          <i class="fa-solid fa-champagne-glasses fa-sm"></i>
-        <% end %>
   </div>
 </header>

--- a/app/views/shared/_sharingbutton.html.erb
+++ b/app/views/shared/_sharingbutton.html.erb
@@ -4,7 +4,7 @@
   <%= form.hidden_field :generated_info, value: @generated_results[:drink_info] %>
   <%= form.hidden_field :image, value: @image %>
   <!-- シェアボタン -->
-  <button type="submit" class="btn btn-outline btn-info bg-black hover:bg-gray-800 text-white flex items-center">
-    <i class="fa-solid fa-champagne-glasses fa-sm"></i>ドリンクをシェアする
+  <button type="submit" class="btn bg-indigo-500 hover:bg-indigo-600 text-white">
+    <i class="fa-solid fa-champagne-glasses fa-sm"></i>ドリンクをシェア
   </button>
 <% end %>

--- a/app/views/socialsharings/index.html.erb
+++ b/app/views/socialsharings/index.html.erb
@@ -1,6 +1,7 @@
 <div class="hero min-h-screen bg-gray-100">
   <div class="container mx-auto px-4 py-8">
-    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-6">
+    <!-- smサイズでは2列、mdサイズでは2列、lgサイズで5列のグリッドレイアウトに調整 -->
+    <div class="grid grid-cols-2 sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-5 gap-6">
       <% @socialsharings.each do |socialsharing| %>
         <div class="relative overflow-hidden shadow-lg rounded-lg">
           <%= link_to socialsharing_path(socialsharing) do %>

--- a/app/views/socialsharings/show.html.erb
+++ b/app/views/socialsharings/show.html.erb
@@ -1,7 +1,7 @@
 
 <div class="hero min-h-screen bg-gray-100">
   <%= render "shared/loading" %>
-  <div class="hero-content flex-col lg:flex-row-reverse">
+  <div class="hero-content flex-col ">
     <!-- 画像の表示 -->
     <div class="max-w-md mx-auto">
       <% if @socialsharing.image.present? %>
@@ -13,7 +13,7 @@
 
     <!-- カード -->
     <div class="card w-full bg-white shadow-xl max-w-lg mx-auto">
-      <div class="card-body">
+      <div class="card-body p-4 sm:p-6">
         <h2 class="card-title text-4xl mb-4">ドリンク情報</h2>
 
         <div class="mb-4">

--- a/app/views/socialsharings/show.html.erb
+++ b/app/views/socialsharings/show.html.erb
@@ -14,6 +14,16 @@
     <!-- カード -->
     <div class="card w-full bg-white shadow-xl max-w-lg mx-auto">
       <div class="card-body p-4 sm:p-6">
+        <div class="relative">
+          <div class="absolute top-1 right-2">
+            <div class="tooltip tooltip-bottom" data-tip="投稿する">
+              <%= link_to new_post_path(tag_names: @socialsharing.generated_drink, body: @socialsharing.generated_word), class: "btn bg-indigo-500 hover:bg-indigo-400 text-white" do %>
+                <i class="fa-solid fa-pen fa-sm"></i>
+              <% end %>
+            </div>
+          </div>
+        </div>
+        
         <h2 class="card-title text-4xl mb-4">ドリンク情報</h2>
 
         <div class="mb-4">


### PR DESCRIPTION
###UIの変更、ドリンクシェアの詳細から投稿に関する修正を行いました。
以下詳細になります
* レビューに応じて、ヘッダーやボタンのUIの修正
* socialsharing/showに投稿するボタンを配置
* 投稿するボタンから投稿フォームへの画面遷移追加
*画面遷移後、詳細のドリンク名、ドリンク言葉がフォームに入るように修正
[![Image from Gyazo](https://i.gyazo.com/41901833c617eeab226b65900693b1e9.gif)](https://gyazo.com/41901833c617eeab226b65900693b1e9)