### PR TITLE
投稿のタグから楽天商品検索機能を追加とその他修正

### DIFF
--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -16,7 +16,7 @@ class Bookmark < ApplicationRecord
     image_data = Base64.decode64(base64)
 
     # 一時ファイルを作成、base64をこのファイルに書き込む
-    file = Tempfile.new([filename, '.png'])
+    file = Tempfile.new([filename, '.webp'])
     file.binmode # バイナリモードでの書き込みを指定
     file << image_data # base64データを書き込む
     file.rewind # ファイルポインタを先頭に戻す

--- a/app/models/socialsharing.rb
+++ b/app/models/socialsharing.rb
@@ -10,13 +10,13 @@ class Socialsharing < ApplicationRecord
     # base64をデコード
     image_data = Base64.decode64(base64)
     # 一時ファイルを作成、base64をこのファイルに書き込む
-    file = Tempfile.new([filename, '.png'])
+    file = Tempfile.new([filename, '.webp'])
     file.binmode # バイナリモードでの書き込みを指定
     file << image_data # base64データを書き込む
     file.rewind # ファイルポインタを先頭に戻す
     # CarrierWaveを使用してアップロード
     self.image = file
     file.close
-    file.unlink # 一時的なファイルのため読み込んだ後削除する
+    # file.unlink # 一時的なファイルのため読み込んだ後削除する
   end
 end

--- a/app/uploaders/avatar_uploader.rb
+++ b/app/uploaders/avatar_uploader.rb
@@ -41,7 +41,7 @@ class AvatarUploader < CarrierWave::Uploader::Base
   # Add an allowlist of extensions which are allowed to be uploaded.
   # For images you might use something like this:
   def extension_allowlist
-    %w[jpg jpeg gif png]
+    %w[jpg jpeg gif png webp]
   end
 
   # Override the filename of the uploaded files:

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -36,10 +36,22 @@ class ImageUploader < CarrierWave::Uploader::Base
   # 画像を100x100pxにリサイズ
   process resize_to_limit: [350, 350]
 
+  # webpに変換
+  def convert_to_webp
+    manipulate! { |img| img.format('webp') }
+  end
+
+  def filename
+    return unless original_filename.present?
+
+    base_name = File.basename(original_filename, '.*')
+    "#{base_name}.webp"
+  end
+
   # Add an allowlist of extensions which are allowed to be uploaded.
   # For images you might use something like this:
   def extension_allowlist
-    %w[jpg jpeg gif png]
+    %w[jpg jpeg gif png webp ]
   end
 
   def filename

--- a/app/views/bookmarks/show.html.erb
+++ b/app/views/bookmarks/show.html.erb
@@ -27,6 +27,21 @@
     <!-- カード -->
     <div class="card w-full bg-white shadow-xl max-w-lg mx-auto">
       <div class="card-body">
+
+
+        <div class="relative">
+          <div class="absolute top-1 right-2">
+            <div class="tooltip tooltip-bottom" data-tip="投稿">
+              <%= link_to posts_path(tag_names:  @bookmark.generated_drink, drink_word: @bookmark.generated_word, body: @bookmark.generated_info ), class: "btn bg-indigo-500 hover:bg-indigo-400 text-white" do %>
+                <i class="fa-solid fa-pen fa-sm"></i>
+              <% end %>
+            </div>
+          </div>
+        </div>
+        
+
+
+
         <h2 class="card-title text-4xl mb-4">ドリンク情報</h2>
 
         <!-- is_original の場合 -->

--- a/app/views/items/_item.html.erb
+++ b/app/views/items/_item.html.erb
@@ -1,14 +1,16 @@
+
+
 <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
-  <% @items.first(3).each do |item| %>
-    <div class="card w-full bg-base-100 shadow-xl">
-      <figure>
-        <%= image_tag(item['mediumImageUrls'][0]) %>
+  <% @items.first(9).each do |item| %>
+    <div class="card w-full bg-base-100 shadow-xl hover:shadow-2xl transition-shadow duration-200">
+      <figure class="px-10 pt-10">
+        <%= image_tag(item['mediumImageUrls'][0], alt: "商品画像", class: "rounded-xl") %>
       </figure>
       <div class="card-body">
         <h2 class="card-title">
-          <%= link_to item.name, item.url, class: "text-sm" %>
+          <%= link_to item.name, item.url, class: "text-lg line-clamp-2" %>
         </h2>
-        <p><%= number_with_delimiter(item.price) %>円</p>
+        <p class="text-xl font-semibold"><%= number_with_delimiter(item.price) %>円</p>
         <div class="flex justify-between items-center text-sm">
           <div class="flex items-center">
             <i class="fas fa-star text-yellow-400 mr-1"></i>

--- a/app/views/items/search.html.erb
+++ b/app/views/items/search.html.erb
@@ -1,13 +1,13 @@
 <div class="hero min-h-screen bg-gray-100">
   <%= render "shared/loading" %>
 
-  <div class="search-box">
-      <%= form_with url: items_search_path, method: :get, local: true do |f| %>
-      <div class="form-group">
-          <%= f.text_field :keyword, value: params[:keyword], class: "form-control" %>
-          <%= f.submit '商品を検索', class: "form-control btn btn-success" %>
+  <div class="search-box p-5">
+    <%= form_with url: items_search_path, method: :get, local: true, class: "form-control" do |f| %>
+      <div class="form-group mb-4">
+        <%= f.text_field :keyword, value: params[:keyword], placeholder: "キーワード" ,class: "input input-bordered input-primary w-full max-w-xs" %>
       </div>
-      <% end %>
+      <%= f.submit '商品を検索', class: "btn btn-primary" %>
+    <% end %>
   <% if @items.present? %>
     <%= render 'items/item' %>
   <% end %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -72,7 +72,14 @@
           <div class="flex flex-wrap gap-2 mb-4">
             <% post.tags.each do |tag| %>
               <span class="badge badge-primary badge-outline mr-2">
-                <%= tag.name %>
+
+
+            <%= link_to items_search_path(keyword: tag.name)  do %>
+              <%= tag.name %>
+            <% end %>
+
+
+
               </span>
             <% end %>
             <% if post.drink_word.present? %>

--- a/app/views/shared/_header_logged_in.html.erb
+++ b/app/views/shared/_header_logged_in.html.erb
@@ -34,6 +34,11 @@
             </li>
           </ul>
         </div>
+        <div class="tooltip tooltip-bottom" data-tip="Share">
+          <%= link_to socialsharings_path, class: "btn bg-indigo-500 hover:bg-indigo-600 text-white ml-2" do %>
+            <i class="fa-solid fa-champagne-glasses fa-sm"></i>
+          <% end %>
+        </div>
       </div>
     </div> 
     <div class="drawer-side z-20	z-index: 20;">

--- a/app/views/shared/_header_logged_out.html.erb
+++ b/app/views/shared/_header_logged_out.html.erb
@@ -23,11 +23,21 @@
           <ul class="menu menu-horizontal">
             <!-- Navbar menu content here -->
             <li>
+              <a href="<%= posts_path %>">
+                <i class="fa-solid fa-pen fa-sm"></i>投稿一覧
+              </a>
+            </li>
+            <li>
               <a href="<%= drinks_path %>">
                 <i class="fa-solid fa-book-open fa-sm "></i>メニュー表
               </a>
             </li>
           </ul>
+        </div>
+        <div class="tooltip tooltip-bottom" data-tip="Share">
+          <%= link_to socialsharings_path, class: "btn bg-indigo-500 hover:bg-indigo-600 text-white ml-2" do %>
+            <i class="fa-solid fa-champagne-glasses fa-sm"></i>
+          <% end %>
         </div>
       </div>
     </div> 

--- a/app/views/socialsharings/index.html.erb
+++ b/app/views/socialsharings/index.html.erb
@@ -1,6 +1,7 @@
 <div class="hero min-h-screen bg-gray-100">
   <%= render "shared/loading" %>
   <div class="container mx-auto px-4 py-8">
+  <h1 class="text-center text-2xl p-4 text-gray-700 font-semibold">みんなが生成したドリンク</h1>
     <!-- smサイズでは2列、mdサイズでは2列、lgサイズで5列のグリッドレイアウトに調整 -->
     <div class="grid grid-cols-3 md:grid-cols-5 gap-4 justify-center">
       <% @socialsharings.each do |socialsharing| %>

--- a/app/views/socialsharings/show.html.erb
+++ b/app/views/socialsharings/show.html.erb
@@ -16,7 +16,7 @@
         <div class="relative">
           <div class="absolute top-1 right-2">
             <div class="tooltip tooltip-bottom" data-tip="投稿する">
-              <%= link_to new_post_path(tag_names: @socialsharing.generated_drink, body: @socialsharing.generated_word), class: "btn bg-indigo-500 hover:bg-indigo-400 text-white" do %>
+              <%= link_to posts_path(tag_names: @socialsharing.generated_drink, drink_word: @socialsharing.generated_word), class: "btn bg-indigo-500 hover:bg-indigo-400 text-white" do %>
                 <i class="fa-solid fa-pen fa-sm"></i>
               <% end %>
             </div>


### PR DESCRIPTION
closes #85 
投稿のタグから楽天商品検索機能を追加しました。
* 投稿のタグに楽天商品検索のリンク付
* 画像を全てwebpに変換
* 動的OGPの健闘に伴ってドリンクシェアのボタンを一旦復元
[![Image from Gyazo](https://i.gyazo.com/8b696eb7b7c2ce94a883c9dee0fcf09c.gif)](https://gyazo.com/8b696eb7b7c2ce94a883c9dee0fcf09c)